### PR TITLE
fix r.Intn() range

### DIFF
--- a/code/cards/deck.go
+++ b/code/cards/deck.go
@@ -64,7 +64,7 @@ func (d deck) shuffle() {
 	r := rand.New(source)
 
 	for i := range d {
-		newPosition := r.Intn(len(d) - 1)
+		newPosition := r.Intn(len(d))
 
 		d[i], d[newPosition] = d[newPosition], d[i]
 	}


### PR DESCRIPTION
from: https://golang.org/pkg/math/rand/#Intn:
"Intn returns, as an int, a non-negative pseudo-random number in [0,n) from the default Source."
therefore, we should use r.Intn(len(d)) that returns ints in [0, len(d)-1] range - including the len(d)-1 one